### PR TITLE
Convert all user-definable defvar into defcustom in bison-mode defgroup.

### DIFF
--- a/bison-mode.el
+++ b/bison-mode.el
@@ -109,40 +109,81 @@
 
 ;; *************** user-definable vars ***************
 
-(defvar bison-rule-separator-column 8
-  "column for rule and production separators \"|\" and \";\"")
-(defvar bison-rule-enumeration-column 16
-  "column for beginning enumeration of a production's rules")
-(defvar bison-decl-type-column 8
-  "columnn in which tokens' and states' types should be when declared")
-(defvar bison-decl-token-column 24
-  "column in which tokens and states are listed when declared,
-as with %token, %type, ...")
+(defgroup bison-mode nil
+  "Bison Mode Control."
+  :group 'c)
 
-
-(defvar bison-all-electricity-off nil
+(defcustom bison-rule-separator-column 8
+  "Column for rule and production separators \"|\" and \";\"."
+  :group 'bison-mode
+  :type 'integer
+  :safe #'integerp)
+(defcustom bison-rule-enumeration-column 16
+  "Column for beginning enumeration of a production's rules."
+  :group 'bison-mode
+  :type 'integer
+  :safe #'integerp)
+(defcustom bison-decl-type-column 8
+  "Column in which tokens' and states' types should be when declared."
+  :group 'bison-mode
+  :type 'integer
+  :safe #'integerp)
+(defcustom bison-decl-token-column 24
+  "Column in which tokens and states are listed when declared,
+as with %token, %type, ..."
+  :group 'bison-mode
+  :type 'integer
+  :safe #'integerp)
+(defcustom bison-all-electricity-off nil
   "non-nil means all electric keys will be disabled,
 nil means that a bison-electric-* key will be on or off based on the individual
-key's electric variable")
+key's electric variable"
+  :group 'bison-mode
+  :type 'boolean
+  :safe #'booleanp)
 
 ;;; i know lisp has the dual name spaces, but i find it more aesthetically
 ;;; pleasing to not take advantage of that
-(defvar bison-electric-colon-v t
-  "non-nil means use an electric colon")
-(defvar bison-electric-pipe-v t
-  "non-nil means use an electric pipe")
-(defvar bison-electric-open-brace-v t
-  "non-nil means use an electric open-brace")
-(defvar bison-electric-close-brace-v t
-  "non-nil means use an electric close-brace")
-(defvar bison-electric-semicolon-v t
-  "non-nil means use an electric semicolon")
-(defvar bison-electric-percent-v t
-  "non-nil means use an electric percent")
-(defvar bison-electric-less-than-v t
-  "non-nil means use an electric less-than")
-(defvar bison-electric-greater-than-v t
-  "non-nil means use an electric greater-than")
+(defcustom bison-electric-colon-v t
+  "Non-nil means use an electric colon."
+  :group 'bison-mode
+  :type 'boolean
+  :safe #'booleanp)
+(defcustom bison-electric-pipe-v t
+  "Non-nil means use an electric pipe."
+  :group 'bison-mode
+  :type 'boolean
+  :safe #'booleanp)
+(defcustom bison-electric-open-brace-v t
+  "Non-nil means use an electric open-brace."
+  :group 'bison-mode
+  :type 'boolean
+  :safe #'booleanp)
+(defcustom bison-electric-close-brace-v t
+  "Non-nil means use an electric close-brace."
+  :group 'bison-mode
+  :type 'boolean
+  :safe #'booleanp)
+(defcustom bison-electric-semicolon-v t
+  "Non-nil means use an electric semicolon."
+  :group 'bison-mode
+  :type 'boolean
+  :safe #'booleanp)
+(defcustom bison-electric-percent-v t
+  "Non-nil means use an electric percent."
+  :group 'bison-mode
+  :type 'boolean
+  :safe #'booleanp)
+(defcustom bison-electric-less-than-v t
+  "Non-nil means use an electric less-than."
+  :group 'bison-mode
+  :type 'boolean
+  :safe #'booleanp)
+(defcustom bison-electric-greater-than-v t
+  "Non-nil means use an electric greater-than."
+  :group 'bison-mode
+  :type 'boolean
+  :safe #'booleanp)
 
 
 (defconst bison-font-lock-keywords
@@ -207,14 +248,14 @@ and \(point\)"
   (setq c-basic-offset 4)
 
   (c-set-offset 'knr-argdecl-intro 0)
-  
+
   ;; remove auto and hungry anything
   (c-toggle-auto-hungry-state -1)
   (c-toggle-auto-newline -1)
   (c-toggle-hungry-state -1)
 
   (use-local-map bison-mode-map)
-  
+
   (define-key bison-mode-map ":" 'bison-electric-colon)
   (define-key bison-mode-map "|" 'bison-electric-pipe)
   (define-key bison-mode-map "{" 'bison-electric-open-brace)
@@ -225,7 +266,7 @@ and \(point\)"
   (define-key bison-mode-map ">" 'bison-electric-greater-than)
 
   (define-key bison-mode-map [tab] 'bison-indent-line)
-  
+
   (make-local-variable 'indent-line-function)
   (setq indent-line-function 'bison-indent-new-line)
   (make-local-variable 'comment-start)
@@ -298,7 +339,7 @@ and \(point\)"
 (defun bison--find-production-opener ()
   "return and goto the point of the nearest production opener above \(point\)"
   (re-search-backward bison--production-re nil t))
-  
+
 
 (defun bison--find-next-production ()
   "return the position of the beginning of the next production,
@@ -371,7 +412,7 @@ ENDER"
   "return t if the point is within a c comment delimited by \"/*\" \"*/\""
   (bison--within-some-sexp-p (regexp-quote comment-start)
 			     (regexp-quote comment-end)))
-	   
+
 
 (defun bison--within-string-p (&optional point)
   "
@@ -386,7 +427,7 @@ found."
 	(setq in-p (not in-p)))
 
       in-p)))
-       
+
 ;;; bison--within-braced-c-expression-p
 ;;; new and improved, no more recursion, does not break when literal strings
 ;;; contain un-matched braces
@@ -433,12 +474,12 @@ save excursion is done higher up, so i dont concern myself here.
 	(goto-char (match-end 0))
 	(if (or (bison--within-c-comment-p)
 		(bison--within-string-p))
-	    
+
 	    (setq count (+ count 1))
 	  (progn
 	    (setq success t)
 	    (setq done t))))
-      
+
       (if success
 	  (let ((end-pt
 		 (condition-case nil
@@ -574,7 +615,7 @@ assumes indenting a new line, i.e. at column 0
 (defun bison-indent-line ()
   "Indent a line of bison code."
   (interactive)
-  
+
   (let* ((pos (- (point-max) (point)))
 	 (reset-pt (function (lambda ()
 			       (if (> (- (point-max) pos) (point))
@@ -590,11 +631,11 @@ assumes indenting a new line, i.e. at column 0
        ;; if you are a line of whitespace, let indent-new-line take care of it
        (ws-line
 	(bison-indent-new-line c-sexp))
-       
+
        ((= section bison--pre-c-decls-section)
 	;; leave things alone
 	)
-       
+
        ((= section bison--c-decls-section)
 	(if c-sexp
 	    (bison--handle-indent-c-sexp section 0 bol)
@@ -603,7 +644,7 @@ assumes indenting a new line, i.e. at column 0
 		(back-to-indentation)
 		(just-no-space)
 		(funcall reset-pt)))))
-       
+
        ((= section bison--bison-decls-section)
 	(let ((opener (bison--bison-decl-opener-p bol eol)))
 	  (cond
@@ -729,7 +770,7 @@ assumes indenting a new line, i.e. at column 0
        ((= section bison--c-code-section)
 	(c-indent-line))
        ))))
-  
+
 ;; *************** electric-functions ***************
 
 (defun bison-electric-colon (arg)
@@ -785,7 +826,7 @@ a word(alphanumerics or '_''s), and there is no previous white space.
 	(indent-to-column bison-rule-enumeration-column)
 	)
     (self-insert-command (prefix-numeric-value arg))))
-	
+
 (defun bison-electric-open-brace (arg)
   "used for the opening brace of a C action definition for production rules,
 if there is only whitespace before \(point\), then put open-brace in
@@ -811,8 +852,8 @@ bison-rule-enumeration-column"
 		     (indent-to-column 0)))))))
 
   (self-insert-command (prefix-numeric-value arg)))
-    
-  
+
+
 (defun bison-electric-close-brace (arg)
   "If the close-brace \"}\" is used as the c-declarations section closer
 in \"%}\", then make sure the \"%}\" indents to the beginning of the line"
@@ -857,7 +898,7 @@ then put it in the 0 column."
 		 (not (previous-non-ws-p))
 		 (not (= (current-column) 0)))
 	    (just-no-space))))
-  
+
   (self-insert-command (prefix-numeric-value arg)))
 
 (defun bison-electric-less-than (arg)
@@ -874,7 +915,7 @@ declaration section, then put it in the bison-decl-type-column column."
 	  (progn
 	    (just-no-space)
 	    (indent-to-column bison-decl-type-column))))
-  
+
   (self-insert-command (prefix-numeric-value arg)))
 
 (defun bison-electric-greater-than (arg)


### PR DESCRIPTION
- Add the defgroup bison-mode, under the defgroup for C.
- All defcustom are in this new defgroup.
- This has no impact on users of Emacs 20 and later when defgroup and defcustom
  were introduced (in 1997).  Since the bison-mode.el was created in 1998, the
  probability that some users may be affected exists but is very low.
- Users can continue to set the variables as if they were declared as defvars.
  They can now use Emacs customization interface to control the values of the user-definable variables.
- Minor cleanup for the docstrings of the affected forms.
- Minor trailing whitespace removal.